### PR TITLE
Fix script asset bundling

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -13,6 +13,6 @@ import '../style.css';
     <div id="map"></div>
 
     <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
-    <script src="/main.js"></script>
+    <script src="/main.js" is:inline></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- avoid bundling the script from `public/` by marking it as inline

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851f63e3e84833097767ce1a331fde0