### PR TITLE
Add dark mode toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,5 @@ All notable changes to this project will be documented in this file.
 - List view showing current time in popular cities
 - Additional pinned time zones on the map
 - Basic styling improvements
+- Dark mode toggle for map and page
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - 🕒 Real-time local time display for multiple cities
 - 🔄 Automatic time updates every minute
 - 📱 Mobile-friendly layout
+- 🌙 Optional dark mode for easier night viewing
 
 ---
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,17 +10,21 @@ import '../style.css';
   </head>
   <body>
     <h1>🕒 World Time Zone Map</h1>
+    <button id="toggle-theme">Toggle Dark Mode</button>
     <ul id="time-list"></ul>
     <div id="map"></div>
 
     <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
     <script is:inline>
       document.addEventListener('DOMContentLoaded', () => {
-        const map = L.map('map').setView([20, 0], 2);
-
-        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        const lightLayer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
           attribution: '© OpenStreetMap contributors'
-        }).addTo(map);
+        });
+        const darkLayer = L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
+          attribution: '© OpenStreetMap contributors, © CARTO'
+        });
+
+        const map = L.map('map', { layers: [lightLayer] }).setView([20, 0], 2);
 
         const cities = [
           { name: 'New York', coords: [40.7128, -74.006], tz: 'America/New_York' },
@@ -63,6 +67,19 @@ import '../style.css';
 
         updateTimes();
         setInterval(updateTimes, 60000);
+
+        const toggle = document.getElementById('toggle-theme');
+        toggle.addEventListener('click', () => {
+          if (map.hasLayer(lightLayer)) {
+            map.removeLayer(lightLayer);
+            darkLayer.addTo(map);
+            document.body.classList.add('dark');
+          } else {
+            map.removeLayer(darkLayer);
+            lightLayer.addTo(map);
+            document.body.classList.remove('dark');
+          }
+        });
       });
     </script>
   </body>

--- a/src/style.css
+++ b/src/style.css
@@ -6,6 +6,41 @@ body {
     color: #333;
 }
 
+button#toggle-theme {
+    margin-bottom: 1rem;
+    padding: 0.5rem 1rem;
+    border: none;
+    background: #007acc;
+    color: white;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+button#toggle-theme:hover {
+    background: #005ea6;
+}
+
+body.dark {
+    background: linear-gradient(135deg, #121212 0%, #333 100%);
+    color: #f0f0f0;
+}
+
+body.dark h1 {
+    color: #64b5f6;
+}
+
+body.dark #map {
+    border-top-color: #64b5f6;
+}
+
+body.dark #time-list li {
+    background: #424242;
+}
+
+body.dark #time-list li:hover {
+    background: #616161;
+}
+
 h1 {
     color: #007acc;
     margin: 1rem 0;


### PR DESCRIPTION
## Summary
- add a dark mode toggle button to allow switching to a dark tile layer
- style dark mode in CSS
- document new dark mode feature
- note feature in changelog

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851fc4414708330860f03dbd440b01a