### PR TITLE
Add day/night shading overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,4 +8,5 @@ All notable changes to this project will be documented in this file.
 - Additional pinned time zones on the map
 - Basic styling improvements
 - Dark mode toggle for map and page
+- Day/night map shading
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - 🔄 Automatic time updates every minute
 - 📱 Mobile-friendly layout
 - 🌙 Optional dark mode for easier night viewing
+- 🌓 Live day/night shading overlay
 
 ---
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -15,6 +15,7 @@ import '../style.css';
     <div id="map"></div>
 
     <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
+    <script src="https://unpkg.com/leaflet-terminator"></script>
     <script is:inline>
       document.addEventListener('DOMContentLoaded', () => {
         const lightLayer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
@@ -25,6 +26,9 @@ import '../style.css';
         });
 
         const map = L.map('map', { layers: [lightLayer] }).setView([20, 0], 2);
+
+        const terminator = L.terminator();
+        terminator.addTo(map);
 
         const cities = [
           { name: 'New York', coords: [40.7128, -74.006], tz: 'America/New_York' },
@@ -67,6 +71,14 @@ import '../style.css';
 
         updateTimes();
         setInterval(updateTimes, 60000);
+
+        function updateTerminator() {
+          terminator.setTime(new Date());
+          terminator.redraw();
+        }
+
+        updateTerminator();
+        setInterval(updateTerminator, 60000);
 
         const toggle = document.getElementById('toggle-theme');
         toggle.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- add day/night shading using `leaflet-terminator`
- document new feature in README
- note new feature in changelog

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851fcd35788833092baacbdb27c545b