### PR TITLE
Fix leaflet terminator browser build

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -15,7 +15,8 @@ import '../style.css';
     <div id="map"></div>
 
     <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
-    <script src="https://unpkg.com/leaflet-terminator"></script>
+    <!-- Use the UMD build so it works in the browser -->
+    <script src="https://unpkg.com/leaflet-terminator/dist/leaflet-terminator.min.js"></script>
     <script is:inline>
       document.addEventListener('DOMContentLoaded', () => {
         const lightLayer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {


### PR DESCRIPTION
## Summary
- use the browser-friendly version of leaflet-terminator to avoid `require` errors

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851fea0c5888330a664ccada1b62434